### PR TITLE
Add comment to indicate testing branch in palette_generator.dart

### DIFF
--- a/lib/test/palette_generator.dart
+++ b/lib/test/palette_generator.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// Testing branch
+
 import 'dart:async';
 import 'dart:math' as math;
 


### PR DESCRIPTION
Include a comment in the `palette_generator.dart` file to clarify the testing branch.